### PR TITLE
fixes for U1-345 and U1-402

### DIFF
--- a/src/components/Timeline/DragEditItem.tsx
+++ b/src/components/Timeline/DragEditItem.tsx
@@ -363,6 +363,7 @@ const DragEditItem = ({
               {renderEventContent
                 ? renderEventContent(event, heightByTimeInterval)
                 : _renderEventContent()}
+                {/* NOTE: comment for now instead of removing
                 <GestureDetector gesture={dragDurationGesture}>
                   <View style={styles.indicatorContainer}>
                     {EditIndicatorComponent ? (
@@ -388,7 +389,7 @@ const DragEditItem = ({
                       </View>
                     )}
                   </View>
-                </GestureDetector>
+                  </GestureDetector>*/}
           </Animated.View>
         </GestureDetector>
       </TouchableOpacity>

--- a/src/components/Timeline/DragEditItem.tsx
+++ b/src/components/Timeline/DragEditItem.tsx
@@ -1,6 +1,6 @@
 import moment from 'moment-timezone';
 import React, { memo, useEffect, useRef, useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   Easing,
@@ -16,26 +16,31 @@ import { useTimelineCalendarContext } from '../../context/TimelineProvider';
 import useTimelineScroll from '../../hooks/useTimelineScroll';
 import type { PackedEvent, ThemeProperties } from '../../types';
 import { roundTo, triggerHaptic } from '../../utils';
+import EventBlock from "./EventBlock"
 
 interface DragEditItemProps {
   selectedEvent: PackedEvent;
+  dayIndex: number;
   onEndDragSelectedEvent?: (event: PackedEvent) => void;
   renderEventContent?: (
     event: PackedEvent,
     heightByTimeInterval: SharedValue<number>
   ) => JSX.Element;
-  isEnabled?: boolean;
+  isEnabled?: boolean; //TODO: remove in the future in favor of isDragEnabled internal state
   EditIndicatorComponent?: JSX.Element;
+  onPressEvent?: (eventItem: PackedEvent) => void;
 }
 
 const EVENT_DEFAULT_COLOR = '#FFFFFF';
 
 const DragEditItem = ({
   selectedEvent,
+  dayIndex,
   onEndDragSelectedEvent,
   renderEventContent,
   isEnabled = true,
   EditIndicatorComponent,
+  onPressEvent
 }: DragEditItemProps) => {
   const {
     columnWidth,
@@ -60,12 +65,14 @@ const DragEditItem = ({
     tzOffset,
     start,
     navigateDelay,
+    isPinchActive,
+    eventAnimatedDuration
   } = useTimelineCalendarContext();
   const { goToNextPage, goToPrevPage, goToOffsetY } = useTimelineScroll();
 
   const event = useRef(selectedEvent).current;
-  const leftWithHourColumn = event.leftByIndex! + hourWidth;
-  const defaultTopPosition = event.top + spaceFromTop;
+  const leftWithHourColumn = event.leftByIndex!;
+  const defaultTopPosition = event.top;
 
   const eventWidth = useSharedValue(event.width);
   const eventLeft = useSharedValue(leftWithHourColumn + event.left);
@@ -78,6 +85,8 @@ const DragEditItem = ({
   const translateX = useSharedValue(0);
   const eventTop = useSharedValue(defaultTopPosition);
   const eventHeight = useSharedValue<number>(event.height);
+
+  const [isDragEnabled, setIsDragEnabled] = useState(false);
 
   useEffect(() => {
     if (useHaptic) {
@@ -185,6 +194,11 @@ const DragEditItem = ({
     if (onEndDragSelectedEvent) {
       onEndDragSelectedEvent(newEvent);
     }
+
+    if(isDragEnabled) {
+      eventLeft.value = leftWithHourColumn
+      setIsDragEnabled(false)
+    }
   };
 
   const clearCurrentInterval = () => {
@@ -206,6 +220,9 @@ const DragEditItem = ({
       };
     })
     .onUpdate(({ translationX, translationY, absoluteX }) => {
+      if(!isDragEnabled) {
+        return
+      }
       const initIndex = event.leftByIndex! / columnWidth;
       const maxIndex = COLUMNS[viewMode] - 1;
       const minRounded = -initIndex;
@@ -221,7 +238,7 @@ const DragEditItem = ({
       const originalTime = originalY / heightByTimeInterval.value;
       const roundedHour = roundTo(originalTime, dragStep, 'up');
       const newTopPosition =
-        roundedHour * heightByTimeInterval.value + spaceFromTop;
+        roundedHour * heightByTimeInterval.value;
       const isSameX = translateX.value === roundedTranslateX;
       const isSameY = eventTop.value === newTopPosition;
       if (!isSameX || !isSameY) {
@@ -293,59 +310,98 @@ const DragEditItem = ({
     return <Text style={[styles.title, theme.eventTitle]}>{event.title}</Text>;
   };
 
+  const _onPress = () => {
+    const eventParams = {
+      ...event,
+      top: event.startHour * heightByTimeInterval.value,
+      height: event.duration * heightByTimeInterval.value,
+      leftByIndex: columnWidth * dayIndex,
+    };
+    onPressEvent?.(eventParams);
+  };
+
+  const _onLongPress = () => {
+    if(!isDragEnabled) {
+      setIsDragEnabled(true)
+      eventLeft.value = event.leftByIndex! + hourWidth;
+    }
+  }
+
   return (
-    <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
-      <GestureDetector gesture={dragPositionGesture}>
-        <Animated.View
-          style={[
-            styles.eventContainer,
-            {
-              backgroundColor: event.color ? event.color : EVENT_DEFAULT_COLOR,
-              top: defaultTopPosition,
-            },
-            event.containerStyle,
-            animatedStyle,
-          ]}
-        >
-          {renderEventContent
-            ? renderEventContent(event, heightByTimeInterval)
-            : _renderEventContent()}
-          <GestureDetector gesture={dragDurationGesture}>
-            <View style={styles.indicatorContainer}>
-              {EditIndicatorComponent ? (
-                EditIndicatorComponent
-              ) : (
-                <View style={styles.indicator}>
-                  <View
-                    style={[
-                      styles.indicatorLine,
-                      theme.editIndicatorColor
-                        ? { backgroundColor: theme.editIndicatorColor }
-                        : undefined,
-                    ]}
-                  />
-                  <View
-                    style={[
-                      styles.indicatorLine,
-                      theme.editIndicatorColor
-                        ? { backgroundColor: theme.editIndicatorColor }
-                        : undefined,
-                    ]}
-                  />
-                </View>
-              )}
-            </View>
-          </GestureDetector>
-        </Animated.View>
-      </GestureDetector>
-      <AnimatedHour
-        currentHour={currentHour}
-        animatedTop={eventTop}
-        top={defaultTopPosition}
-        hourWidth={hourWidth}
-        theme={theme}
-        hourFormat={hourFormat}
-      />
+    <View style={[StyleSheet.absoluteFill]} pointerEvents="box-none">
+      {isDragEnabled &&
+        <EventBlock
+          key={event.id}
+          event={{
+            ...event,
+            top: eventTop.value
+          }}
+          dayIndex={dayIndex}
+          columnWidth={columnWidth}
+          timeIntervalHeight={timeIntervalHeight}
+          onPressEvent={onPressEvent}
+          renderEventContent={renderEventContent}
+          theme={theme}
+          eventAnimatedDuration={eventAnimatedDuration}
+          isPinchActive={isPinchActive}
+          heightByTimeInterval={heightByTimeInterval}
+        />
+      }
+      <TouchableOpacity onPress={_onPress} delayLongPress={800} onLongPress={_onLongPress} activeOpacity={1}>
+        <GestureDetector gesture={dragPositionGesture}>
+          <Animated.View
+            style={[
+              styles.eventContainer,
+              {
+                backgroundColor: event.color ? event.color : EVENT_DEFAULT_COLOR,
+                top: defaultTopPosition,
+              },
+              event.containerStyle,
+              animatedStyle,
+            ]}
+          >
+              {renderEventContent
+                ? renderEventContent(event, heightByTimeInterval)
+                : _renderEventContent()}
+                <GestureDetector gesture={dragDurationGesture}>
+                  <View style={styles.indicatorContainer}>
+                    {EditIndicatorComponent ? (
+                      EditIndicatorComponent
+                    ) : (
+                      <View style={styles.indicator}>
+                        <View
+                          style={[
+                            styles.indicatorLine,
+                            theme.editIndicatorColor
+                              ? { backgroundColor: theme.editIndicatorColor }
+                              : undefined,
+                          ]}
+                        />
+                        <View
+                          style={[
+                            styles.indicatorLine,
+                            theme.editIndicatorColor
+                              ? { backgroundColor: theme.editIndicatorColor }
+                              : undefined,
+                          ]}
+                        />
+                      </View>
+                    )}
+                  </View>
+                </GestureDetector>
+          </Animated.View>
+        </GestureDetector>
+      </TouchableOpacity>
+      {isDragEnabled &&
+        <AnimatedHour
+          currentHour={currentHour}
+          animatedTop={eventTop}
+          top={defaultTopPosition}
+          hourWidth={hourWidth}
+          theme={theme}
+          hourFormat={hourFormat}
+        />
+      }
     </View>
   );
 };

--- a/src/components/Timeline/EventBlock.tsx
+++ b/src/components/Timeline/EventBlock.tsx
@@ -81,7 +81,7 @@ const EventBlock = ({
     }
 
     return {
-      top: withTiming(event.startHour * heightByTimeInterval.value, {
+      top: withTiming(event.top, {
         duration: eventAnimatedDuration,
       }),
       height: withTiming(eventHeight, {
@@ -119,13 +119,16 @@ const EventBlock = ({
       ]}
     >
       <TouchableOpacity
-        disabled={!!selectedEventId}
+        disabled
         delayLongPress={300}
         onPress={_onPress}
         onLongPress={_onLongPress}
         style={[
           StyleSheet.absoluteFill,
-          { backgroundColor: event.color || EVENT_DEFAULT_COLOR },
+          { 
+            backgroundColor: event.color || EVENT_DEFAULT_COLOR,
+            opacity: 0.3 
+          },
         ]}
         activeOpacity={0.6}
       >

--- a/src/components/Timeline/TimelinePage.tsx
+++ b/src/components/Timeline/TimelinePage.tsx
@@ -15,10 +15,10 @@ import { COLUMNS } from '../../constants';
 import { useTimelineCalendarContext } from '../../context/TimelineProvider';
 import type { EventItem, PackedEvent, UnavailableItemProps } from '../../types';
 import { convertPositionToISOString, divideEventsByColumns } from '../../utils';
-import EventBlock from './EventBlock';
 import NowIndicator from './NowIndicator';
 import TimelineBoard from './TimelineBoard';
 import TimelineHours from './TimelineHours';
+import DragEditItem from './DragEditItem';
 
 interface TimelinePageProps {
   startDate: string;
@@ -39,6 +39,13 @@ interface TimelinePageProps {
   renderHalfLineCustom?: (width: number) => JSX.Element;
   halfLineContainerStyle?: ViewStyle;
   currentDate: string;
+  isEnabled?: boolean;
+  onEndDragSelectedEvent?: (event: PackedEvent) => void;
+  renderSelectedEventContent?: (
+    event: PackedEvent,
+    timeIntervalHeight: SharedValue<number>
+  ) => JSX.Element;
+  EditIndicatorComponent?: JSX.Element;
 }
 
 const TimelinePage = ({
@@ -57,6 +64,10 @@ const TimelinePage = ({
   renderHalfLineCustom,
   halfLineContainerStyle,
   currentDate,
+  isEnabled,
+  onEndDragSelectedEvent,
+  renderSelectedEventContent,
+  EditIndicatorComponent
 }: TimelinePageProps) => {
   const {
     rightSideWidth,
@@ -141,22 +152,21 @@ const TimelinePage = ({
 
   const _renderEvent = (event: PackedEvent, dayIndex: number) => {
     return (
-      <EventBlock
-        key={event.id}
-        event={event}
+      <DragEditItem
+        selectedEvent={{
+          ...event,
+          top: event.startHour * heightByTimeInterval.value,
+          height: event.duration * heightByTimeInterval.value,
+          leftByIndex: columnWidth * dayIndex,
+        }}
         dayIndex={dayIndex}
-        columnWidth={columnWidth}
-        timeIntervalHeight={timeIntervalHeight}
+        onEndDragSelectedEvent={onEndDragSelectedEvent}
+        isEnabled={isEnabled}
+        EditIndicatorComponent={EditIndicatorComponent}
+        renderEventContent={renderSelectedEventContent || renderEventContent}
         onPressEvent={onPressEvent}
-        onLongPressEvent={onLongPressEvent}
-        renderEventContent={renderEventContent}
-        selectedEventId={selectedEventId}
-        theme={theme}
-        eventAnimatedDuration={eventAnimatedDuration}
-        isPinchActive={isPinchActive}
-        heightByTimeInterval={heightByTimeInterval}
       />
-    );
+    )
   };
 
   const _renderTimelineColumn = (dayIndex: number) => {

--- a/src/components/Timeline/TimelineSlots.tsx
+++ b/src/components/Timeline/TimelineSlots.tsx
@@ -18,7 +18,6 @@ import Animated, {
 } from 'react-native-reanimated';
 import { useTimelineCalendarContext } from '../../context/TimelineProvider';
 import type { EventItem, PackedEvent, UnavailableItemProps } from '../../types';
-import DragEditItem from './DragEditItem';
 import TimelineHours from './TimelineHours';
 import TimelinePage from './TimelinePage';
 
@@ -149,6 +148,10 @@ const TimelineSlots = ({
         selectedEventId={extraData?.selectedEventId}
         renderEventContent={renderEventContent}
         currentDate={extraData.currentDate}
+        isEnabled={editEventGestureEnabled}
+        onEndDragSelectedEvent={onEndDragSelectedEvent}
+        renderSelectedEventContent={renderSelectedEventContent}
+        EditIndicatorComponent={EditIndicatorComponent}
         {...other}
       />
     );
@@ -259,15 +262,6 @@ const TimelineSlots = ({
       >
         {_renderSlots()}
       </Animated.View>
-      {!!selectedEvent?.id && (
-        <DragEditItem
-          selectedEvent={selectedEvent}
-          onEndDragSelectedEvent={onEndDragSelectedEvent}
-          isEnabled={editEventGestureEnabled}
-          EditIndicatorComponent={EditIndicatorComponent}
-          renderEventContent={renderSelectedEventContent || renderEventContent}
-        />
-      )}
     </ScrollView>
   );
 };


### PR DESCRIPTION
- fix: mask starts at the bottom
- remove time bar handle
- make TimelineSlot component draggable on first long-press
  - do not use DragEditItem in TimelineSlots
  - use DragEditItem in TimelinePage instead of EventBlock
  - use EventBlock inside DragEditItem
  - control the draggable boolean state internally in DragEditItem
  - make DragEditItem pressable
  - make EventBlock untouchable

unwritten-hair impacted tickets: U1-345, U1-402