### PR TITLE
Fix: Long tap and single tap - produces different timezones when creating a new manual booking

### DIFF
--- a/src/hooks/useDragCreateGesture.tsx
+++ b/src/hooks/useDragCreateGesture.tsx
@@ -139,8 +139,7 @@ const useDragCreateGesture = ({ onDragCreateEnd }: useDragCreateGesture) => {
     const time = event.y / heightByTimeInterval.value;
     const positionIndex = Math.round(event.x / columnWidth);
     const startDate = pages[viewMode].data[currentIndex.value];
-    const eventStart = moment
-      .tz(startDate, tzOffset)
+    const eventStart = moment(startDate)
       .add(positionIndex, 'd')
       .add(time, 'h')
       .add(start, 'h');


### PR DESCRIPTION
### Description
- the `_onEnd` method inside the hook `useDragCreateGesture` is using timezone when constructing the start time (this `_onEnd` method is used in creating a new entry in the calendar via drag and drop)
- however, the function `convertPositionToISOString` in `utils.ts` is not using a timezone to construct the start time (this function is used in creating a new entry in the calendar via press gesture)
- so that's basically the issue why the drag/drop and the onpress gestures produce different start time values

### Unwritten Ticket
https://unwritten-hair.atlassian.net/browse/U1-524